### PR TITLE
12 uiwant doレスポンシブ対応

### DIFF
--- a/src/app/confirmation/page.tsx
+++ b/src/app/confirmation/page.tsx
@@ -20,15 +20,15 @@ export default function Confirmation() {
   };
   return (
     <>
-      <div className='flex flex-col  min-h-screen min-w-screen justify-center items-center px-10'>
+      <div className='flex flex-col  min-h-screen min-w-screen md:justify-center items-center px-10 justify-start'>
         <Header title='' isSend={true} />
-        <div className='w-full h-full flex justify-center items-end px-10 relative'>
-          <Image src={panImage} alt='' width={300} objectFit='contain' className='w-5/6' />
-          <div className='flex flex-col'>
+        <div className='w-full h-full flex md:flex-row flex-col grow md:items-end justify-center items-center md:px-10 relative'>
+          <Image src={panImage} alt='' layout='full' objectFit='contain' className='w-5/6' />
+          <div className='flex md:flex-col md:justify-start flex-row justify-center md:mt-0 mt-20'>
             <GenericButton label='蓋を閉じる' func={handleSend} colour='#FEF4EF' />
-            <br></br>
+            <br className='md:block hidden'></br>
             <GenericButton label='鍋を空にする' func={handleDeleteIngredients} colour='#FEF4EF' />
-            <br></br>
+            <br className='md:block hidden'></br>
           </div>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import Ingredient from '../components/atoms/Ingredient';
+
+export default function Home() {
+  return (
+    <main className='flex min-h-screen flex-col items-center justify-between p-24'>
+      <Ingredient />
+    </main>
+  );
+}

--- a/src/app/receive/page.tsx
+++ b/src/app/receive/page.tsx
@@ -9,10 +9,12 @@ export default function Receive() {
   }
   return (
     <>
-      <div className='flex flex-col  min-h-screen min-w-screen justify-center items-center px-10'>
+      <div className='flex flex-col min-h-screen min-w-screen md:justify-center items-center px-10 justify-start'>
         <Header title='提案されたレシピたちです♪' isSend={false} />
-        <div className='w-full h-full flex flex-col justify-center items-center px-10'>
-          <div className='w-5/6 h-full grid grid-cols-3 gap-10'>{result}</div>
+        <div className='w-full h-full flex flex-col justify-center items-center lg:px-10'>
+          <div className='lg:w-5/6 w-full h-full grid lg:grid-cols-3 lg:gap-10 md:grid-cols-2 grid-cols-1 gap-5'>
+            {result}
+          </div>
         </div>
       </div>
     </>

--- a/src/app/send/page.tsx
+++ b/src/app/send/page.tsx
@@ -4,7 +4,7 @@ import 'ui-neumorphism/dist/index.css';
 import Ingredient from '@/components/atoms/Ingredient';
 import Header from '@/components/molecules/Header';
 import InputBox from '@/components/atoms/InputBox';
-import InputBoxDisabled from '@/components/atoms/InputBoxDisabled';
+import DisabledInputBox from '@/components/atoms/DisabledInputBox';
 import { TypeOfIngredient } from '@/models/TypeOfIngredient';
 import pic from '../../assets/image_png.png';
 
@@ -13,7 +13,7 @@ const ingredient: TypeOfIngredient = {
   name: 'チキン',
   url: pic,
   description:
-    'おいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニク',
+    'おいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニクおいしいトリニク',
 };
 
 export default function Send() {
@@ -23,16 +23,35 @@ export default function Send() {
     ingredients.push(<Ingredient ingredient={ingredient} />);
   }
 
+  // グローバルに値を追加する
+  const handleAddIngredient = (e) => {
+    // modalで追加の方はingredient objをグローバルに登録しているがoptionで選択する方はobjをvalueにできないので
+    // グローバル登録時にはstring(ingredient.name)とingredientを紐づける必要
+    // もしくは，下の送信UIに表示するのは文字だけなのでそのままstringだけグローバルに登録するreducerを用意しても良い
+    console.log(e.target.value, 'is added to the list!');
+    return null;
+  };
+
   return (
     <>
-      <div className='flex flex-col  min-h-screen min-w-screen justify-center items-center px-10'>
+      <div className='flex flex-col min-h-screen min-w-screen md:justify-center items-center px-10 justify-start'>
         <Header title='材料を選んでください' isSend={true} />
         <div className='w-full h-full flex flex-col justify-center items-center px-10'>
-          <div className='w-full h-full grid grid-cols-6 grid-rows-3 gap-10'>{ingredients}</div>
+          {/* The following component is not visible on mobile. */}
+          <div className='w-full h-full md:grid lg:grid-cols-6 lg:gap-10 md:grid-cols-4 md:gap-5 hidden'>
+            {ingredients}
+          </div>
+
+          {/* The following component is only for mobile */}
+          <select onChange={(e) => handleAddIngredient(e)} className='md:hidden'>
+            <option value={ingredient.name}>{ingredient.name}</option>
+            <option value={ingredient.name}>{ingredient.name}</option>
+            <option value={ingredient.name}>{ingredient.name}</option>
+          </select>
         </div>
       </div>
       <div className='my-10 invisible'>
-        <InputBoxDisabled />
+        <DisabledInputBox />
       </div>
       <InputBox />
     </>

--- a/src/components/atoms/DisabledInputBox.tsx
+++ b/src/components/atoms/DisabledInputBox.tsx
@@ -6,7 +6,7 @@ import pic from '../../assets/image_png.png';
 import sendIcon from '../../assets/send-icon.svg';
 import { useRouter } from 'next/navigation';
 
-export default function InputBox() {
+export default function DisabledInputBox() {
   const router = useRouter();
 
   // グローバルに定義されたingredientsから値を取得
@@ -38,11 +38,12 @@ export default function InputBox() {
             marginRight: '1%',
           }}
         >
+          {/* 中のアイテム */}
           <Card
             elevation={3}
             inset
             style={{
-              display: 'inline-block',
+              display: 'none',
               width: '7%',
               aspectRatio: '1/1',
               borderRadius: '50%',
@@ -69,7 +70,7 @@ export default function InputBox() {
           class='send_button'
           onClick={() => handlePageSwitch('/confirmation')}
           bgColor='#EF9090'
-          style={{ position: 'relative', width: '6%', height: '10%', aspectRatio: '1/1', borderRadius: '25px' }}
+          style={{ position: 'relative', borderRadius: '25px' }}
         >
           <Image src={sendIcon} alt='' layout='fill' objectFit='contain' className='p-5' />
         </Button>

--- a/src/components/atoms/GenericButton.tsx
+++ b/src/components/atoms/GenericButton.tsx
@@ -10,7 +10,7 @@ export default function GenericButton(props: { label: string; func: () => void; 
         size='large'
         style={{ paddingRight: '20px', paddingLeft: '20px', paddingTop: '15px', paddingBottom: '15px' }}
       >
-        <span className='text-xl text-thick'>{props.label}</span>
+        <span className='md:text-xl text-thick'>{props.label}</span>
       </Button>
     </>
   );

--- a/src/components/atoms/InputBox.tsx
+++ b/src/components/atoms/InputBox.tsx
@@ -22,6 +22,11 @@ export default function InputBox() {
     router.push(path);
   };
 
+  const handleDeleteIngredients = () => {
+    console.log("Ingredients are deleted. The user'll be sent back to the send page.");
+    return null;
+  };
+
   return (
     <>
       <div className='w-full fixed bottom-5 left-0 right-0 flex justify-center items-center'>
@@ -38,11 +43,11 @@ export default function InputBox() {
             marginRight: '1%',
           }}
         >
+          {/* The following component cannot be seen in mobile */}
           <Card
             elevation={3}
             inset
             style={{
-              display: 'inline-block',
               width: '7%',
               aspectRatio: '1/1',
               borderRadius: '50%',
@@ -50,6 +55,7 @@ export default function InputBox() {
               marginRight: '2%',
               backgroundColor: 'white',
             }}
+            className='lg:inline-block hidden'
           >
             <Image src={ingredient.url} alt='Picture of the author' layout='fill' objectFit='contain' />
             <IconButton
@@ -60,9 +66,31 @@ export default function InputBox() {
               bgColor='#E4EBF5'
               className='absolute'
               style={{ top: '-7px', right: '-13px' }}
+              onClick={handleDeleteIngredients}
             >
               <span style={{ fontSize: '18px', margin: '1px 0px 0px 1px', fontWeight: 'bold' }}>&times;</span>
             </IconButton>
+          </Card>
+
+          {/* The following component is only for mobile */}
+          <Card
+            elevation={0}
+            style={{
+              width: '100%',
+              borderRadius: '50px',
+              paddingTop: '5px',
+              paddingRight: '20px',
+              paddingBottom: '5px',
+              paddingLeft: '20px',
+              backgroundColor: 'white',
+              marginBottom: '1%',
+            }}
+            className='flex justify-between items-center lg:hidden'
+          >
+            <div>{ingredient.name}</div>
+            <Button rounded color='#5E5E5E' bgColor='#E4EBF5' size='small' onClick={handleDeleteIngredients}>
+              <span style={{ fontSize: '18px', margin: '1px 0px 0px 1px', fontWeight: 'bold' }}>&times;</span>
+            </Button>
           </Card>
         </Card>
         <Button

--- a/src/components/atoms/Switcher.tsx
+++ b/src/components/atoms/Switcher.tsx
@@ -2,12 +2,12 @@ import Link from 'next/link';
 export default function Switcher(props: { isSend: boolean }) {
   return (
     <>
-      <p className='w-1/3 text-base text-center'>
-        <Link href='/send' className={props.isSend ? 'text-primary' : 'text-base hover:text-primary'}>
+      <p className='w-1/3 md:text-base text-xs text-neutral text-center'>
+        <Link href='/send' className={props.isSend ? 'text-primary' : 'text-neutral hover:text-primary'}>
           送信側
         </Link>
         |
-        <Link href='/receive' className={!props.isSend ? 'text-primary' : 'text-base hover:text-primary'}>
+        <Link href='/receive' className={!props.isSend ? 'text-primary' : 'text-neutral hover:text-primary'}>
           受信側
         </Link>
       </p>

--- a/src/components/atoms/Title.tsx
+++ b/src/components/atoms/Title.tsx
@@ -1,7 +1,7 @@
 export default function Title(props: { title: string }) {
   return (
     <>
-      <h1 className='w-1/3 text-center text-3xl antialiased text-primary'>{props.title}</h1>
+      <h1 className='md:w-1/3 w-full text-center md:text-3xl text-xl antialiased text-primary'>{props.title}</h1>
     </>
   );
 }

--- a/src/components/molecules/Header.tsx
+++ b/src/components/molecules/Header.tsx
@@ -8,7 +8,7 @@ export default function Header(props: { title: string; isSend: boolean }) {
   };
   return (
     <>
-      <div className='w-full pt-10 pb-20 flex justify-end'>
+      <div className='w-full pt-10 md:pb-20 pb-10 flex md:justify-end md:flex-row flex-col-reverse items-center'>
         {!props.isSend ? (
           <div className='w-1/3 flex justify-start'>
             <GenericButton label='<蓋を開ける' func={openLid} colour='#FEF4EF' />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,7 @@ module.exports = {
       colors: {
         primary: '#EF9090',
         secondary: '#A492F9',
-        base: '#CDD4DD',
+        neutral: '#CDD4DD',
         thick: '#5E5E5E',
         thin: '#E4EBF5',
         layout: '#FEF4EF',


### PR DESCRIPTION
主なレイアウト変更点です<br></br>
## 送信ページ
- 送信InputBoxUI:
   - PC: アイコン有り＋削除ボタン
   - tablet & mobile: アイコンなし．文字だけリスト＋削除ボタン
- 材料データUI:
   - PC & tablet: アイコン
   - mobile: リストボックス（現時点では見た目はともかく取り急ぎ）
- ヘッダー:
   -  mobile: 縦

## 確認ページ
- 鍋＆ボタン:
   - mobile: 縦
- ヘッダー:
   - mobile: 縦

## 受信ページ
- カード:
   - PC, tablet, mobileでそれぞれカラム数とギャップ調節してます
- ヘッダー:
   - mobile: 縦